### PR TITLE
Fix code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/src/main/java/com/ironoc/portfolio/client/GitClient.java
+++ b/src/main/java/com/ironoc/portfolio/client/GitClient.java
@@ -35,7 +35,9 @@ public class GitClient implements Client {
     @Override
     public HttpsURLConnection createConn(String url) throws IOException {
         String baseUrl = propertyConfig.getGitApiEndpoint();
-        if (!urlUtils.isValidURL(url) || !url.startsWith(baseUrl)) {
+        URL urlBase = new URL(baseUrl);
+        String base = urlBase.getProtocol() + "://" + urlBase.getHost();
+        if (!urlUtils.isValidURL(url) || !url.startsWith(base)) {
             log.error("The url is not valid for GIT client connection, url={}", url);
             return null;
         }

--- a/src/main/java/com/ironoc/portfolio/client/GitClient.java
+++ b/src/main/java/com/ironoc/portfolio/client/GitClient.java
@@ -34,7 +34,8 @@ public class GitClient implements Client {
 
     @Override
     public HttpsURLConnection createConn(String url) throws IOException {
-        if (!urlUtils.isValidURL(url)) {
+        String baseUrl = propertyConfig.getGitApiEndpoint();
+        if (!urlUtils.isValidURL(url) || !url.startsWith(baseUrl)) {
             log.error("The url is not valid for GIT client connection, url={}", url);
             return null;
         }

--- a/src/test/java/com/ironoc/portfolio/client/GitClientTest.java
+++ b/src/test/java/com/ironoc/portfolio/client/GitClientTest.java
@@ -42,7 +42,7 @@ public class GitClientTest {
     @Mock
     private InputStream inputStreamMock;
 
-    private static final String TEST_URL = "https://cloud-conor.com";
+    private static final String TEST_URL = "https://unittest.github.com/users/conorheffron/repos";
 
     @Test
     public void test_readInputStream_fail() throws IOException {
@@ -79,6 +79,7 @@ public class GitClientTest {
     @Test
     public void test_createConn_without_token_success() throws IOException {
         // given
+        when(propertyConfigMock.getGitApiEndpoint()).thenReturn(TEST_URL);
         when(urlUtilsMock.isValidURL(TEST_URL)).thenReturn(true);
 
         // when
@@ -86,6 +87,7 @@ public class GitClientTest {
 
         // then
         verify(urlUtilsMock).isValidURL(TEST_URL);
+        verify(propertyConfigMock).getGitApiEndpoint();
         verify(propertyConfigMock).getGitFollowRedirects();
         verify(propertyConfigMock).getGitTimeoutConnect();
         verify(propertyConfigMock).getGitTimeoutRead();
@@ -98,6 +100,7 @@ public class GitClientTest {
     @Test
     public void test_createConn_with_token_success() throws IOException {
         // given
+        when(propertyConfigMock.getGitApiEndpoint()).thenReturn(TEST_URL);
         when(urlUtilsMock.isValidURL(TEST_URL)).thenReturn(true);
         when(secretManagerMock.getGitSecret()).thenReturn("test_fake_token");
 
@@ -106,6 +109,7 @@ public class GitClientTest {
 
         // then
         verify(urlUtilsMock).isValidURL(TEST_URL);
+        verify(propertyConfigMock).getGitApiEndpoint();
         verify(propertyConfigMock).getGitFollowRedirects();
         verify(propertyConfigMock).getGitTimeoutConnect();
         verify(propertyConfigMock).getGitTimeoutRead();
@@ -118,6 +122,7 @@ public class GitClientTest {
     @Test
     public void test_createConn_invalid_url_fail() throws IOException {
         // given
+        when(propertyConfigMock.getGitApiEndpoint()).thenReturn(TEST_URL);
         when(urlUtilsMock.isValidURL(TEST_URL)).thenReturn(false);
 
         // when
@@ -125,6 +130,7 @@ public class GitClientTest {
 
         // then
         verify(urlUtilsMock).isValidURL(TEST_URL);
+        verify(propertyConfigMock).getGitApiEndpoint();
         verify(propertyConfigMock, never()).getGitFollowRedirects();
         verify(propertyConfigMock, never()).getGitTimeoutConnect();
         verify(propertyConfigMock, never()).getGitTimeoutRead();


### PR DESCRIPTION
Fixes [https://github.com/conorheffron/ironoc/security/code-scanning/2](https://github.com/conorheffron/ironoc/security/code-scanning/2)

To fix the SSRF vulnerability, we should ensure that the URL used in the `createConn` method is restricted to a specific domain or a list of allowed URLs. This can be achieved by validating the URL against a whitelist of allowed domains or by ensuring it starts with a specific base URL.

1. **General Fix Approach:**
   - Validate the URL against a whitelist of allowed domains or ensure it starts with a specific base URL.
   - Reject or sanitize any URLs that do not meet the criteria.

2. **Detailed Fix:**
   - Modify the `createConn` method in `GitClient` to validate the URL against a base URL from the configuration.
   - Ensure that the URL starts with the base URL before proceeding to create the connection.

3. **Specific Changes:**
   - Update the `createConn` method in `GitClient` to include the base URL validation.
   - Add a method to validate the URL against the base URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
