### PR TITLE
Bump software.amazon.awssdk:aws-sdk-java from 2.28.11 to 2.28.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>aws-sdk-java</artifactId>
-			<version>2.28.11</version>
+			<version>2.28.16</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Bumps software.amazon.awssdk:aws-sdk-java from 2.28.11 to 2.28.16.

---
updated-dependencies:
- dependency-name: software.amazon.awssdk:aws-sdk-java dependency-type: direct:production update-type: version-update:semver-patch ...