### PR TITLE
Bump io.swagger.core.v3:swagger-annotations from 2.2.25 to 2.2.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 		<dependency>
 			<groupId>io.swagger.core.v3</groupId>
 			<artifactId>swagger-annotations</artifactId>
-			<version>2.2.25</version>
+			<version>2.2.26</version>
 		</dependency>
 		<!-- AWS-->
 		<dependency>


### PR DESCRIPTION
Bumps io.swagger.core.v3:swagger-annotations from 2.2.25 to 2.2.26.

---
updated-dependencies:
- dependency-name: io.swagger.core.v3:swagger-annotations dependency-type: direct:production update-type: version-update:semver-patch ...