### PR TITLE
v7.0.1 patch release for failing brews API call

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,10 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.x.x   | :white_check_mark: |
-| <= 4.x.x   | :x:                |
+| Version  | Supported          |
+|----------| ------------------ |
+| 7.x.x    | :white_check_mark: |
+| <= 6.x.x | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorheffron/ironoc-frontend",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dependencies": {
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.28.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "private": false,
   "dependencies": {
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/components/CoffeeHome.js
+++ b/frontend/src/components/CoffeeHome.js
@@ -10,7 +10,7 @@ function CoffeeHome() {
     const [coffeeItems, setCoffeeItems] = useState([]);
 
     useEffect(() => {
-        axios.get('/coffees')
+        axios.get('/coffees-graph-ql')
             .then(response => setCoffeeItems(response.data))
             .catch(error => console.error('Error fetching coffee details:', error));
     }, []);

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
 		<node.version>v20.16.0</node.version>
 		<npm.version>10.8.1</npm.version>
+		<kotlin.version>1.5.0</kotlin.version>
 	</properties>
 
 	<dependencies>
@@ -69,6 +70,36 @@
 			<artifactId>spring-boot-starter-tomcat</artifactId>
 			<version>${spring.version}</version>
 			<scope>provided</scope>
+		</dependency>
+		<!-- Spring Boot Starter GraphQL -->
+<!--		<dependency>-->
+<!--			<groupId>com.graphql-java-kickstart</groupId>-->
+<!--			<artifactId>graphql-spring-boot-starter</artifactId>-->
+<!--			<version>11.1.0</version>-->
+<!--		</dependency>-->
+		<!-- GraphQL Client -->
+<!--		<dependency>-->
+<!--			<groupId>com.graphql-java-kickstart</groupId>-->
+<!--			<artifactId>graphql-java-client</artifactId>-->
+<!--			<version>1.0.0</version>-->
+<!--		</dependency>-->
+		<dependency>
+			<groupId>com.graphql-java-kickstart</groupId>
+			<artifactId>graphql-spring-boot-starter</artifactId>
+			<version>15.0.0</version>
+		</dependency>
+
+		<!-- testing facilities -->
+		<dependency>
+			<groupId>com.graphql-java-kickstart</groupId>
+			<artifactId>graphql-spring-boot-starter-test</artifactId>
+			<version>15.0.0</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Jackson for JSON processing -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<!-- Jakarta -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<node.version>v20.16.0</node.version>
 		<npm.version>10.8.1</npm.version>
 		<kotlin.version>1.5.0</kotlin.version>
+		<graphql.vers>15.0.0</graphql.vers>
 	</properties>
 
 	<dependencies>
@@ -71,29 +72,16 @@
 			<version>${spring.version}</version>
 			<scope>provided</scope>
 		</dependency>
-		<!-- Spring Boot Starter GraphQL -->
-<!--		<dependency>-->
-<!--			<groupId>com.graphql-java-kickstart</groupId>-->
-<!--			<artifactId>graphql-spring-boot-starter</artifactId>-->
-<!--			<version>11.1.0</version>-->
-<!--		</dependency>-->
-		<!-- GraphQL Client -->
-<!--		<dependency>-->
-<!--			<groupId>com.graphql-java-kickstart</groupId>-->
-<!--			<artifactId>graphql-java-client</artifactId>-->
-<!--			<version>1.0.0</version>-->
-<!--		</dependency>-->
+		<!-- GraphQL -->
 		<dependency>
 			<groupId>com.graphql-java-kickstart</groupId>
 			<artifactId>graphql-spring-boot-starter</artifactId>
-			<version>15.0.0</version>
+			<version>${graphql.vers}</version>
 		</dependency>
-
-		<!-- testing facilities -->
 		<dependency>
 			<groupId>com.graphql-java-kickstart</groupId>
 			<artifactId>graphql-spring-boot-starter-test</artifactId>
-			<version>15.0.0</version>
+			<version>${graphql.vers}</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- Jackson for JSON processing -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>conorheffron</groupId>
 	<artifactId>ironoc</artifactId>
-	<version>7.0.0</version>
+	<version>7.0.1</version>
 	<packaging>war</packaging>
 
 	<distributionManagement>

--- a/src/main/java/net/ironoc/portfolio/service/GraphQLClientService.java
+++ b/src/main/java/net/ironoc/portfolio/service/GraphQLClientService.java
@@ -1,0 +1,77 @@
+package net.ironoc.portfolio.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.ironoc.portfolio.logger.AbstractLogger;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class GraphQLClientService extends AbstractLogger {
+
+    private final ObjectMapper objectMapper;
+
+    private final ResourceLoader resourceLoader;
+
+    private final RestTemplate restTemplate;
+
+    private static final String GRAPHQL_URL = "https://api.sampleapis.com/coffee/graphql";// TODO move to yml
+
+    @Autowired
+    public GraphQLClientService(RestTemplateBuilder restTemplateBuilder,
+                          ObjectMapper objectMapper, ResourceLoader resourceLoader) {
+        this.restTemplate = restTemplateBuilder.build();
+        this.objectMapper = objectMapper;
+        this.resourceLoader = resourceLoader;
+    }
+
+    public Map<String, Object> fetchCoffeeDetails() throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Content-Type", "application/json");
+
+        String query = this.loadQuery("query.graphql");
+        if (!StringUtils.isBlank(query)) {
+            String requestPayload = "{ \"query\": \"" + query.replace("\"", "\\\"").replace("\n", " ") + "\" }";
+            HttpEntity<String> request = new HttpEntity<>(requestPayload, headers);
+            ResponseEntity<String> response = restTemplate.exchange(GRAPHQL_URL, HttpMethod.POST, request, String.class);
+            return objectMapper.readValue(response.getBody(), Map.class);
+        } else {
+            return new HashMap<>();
+        }
+    }
+
+    private String loadQuery(String fileName) {
+        Resource resource = resourceLoader.getResource("classpath:graphql" + File.separator + fileName);
+        try {
+            return new String(Files.readAllBytes(Paths.get(resource.getURI())));
+        } catch (IOException e) {
+            error("Unexpected exception occurred loading GraphQL query, msg={}", e.getMessage());
+        }
+        return null;
+    }
+
+    public List<Map<String, Object>> getAllIcedCoffees(Map<String, Object> response) {
+        return (List<Map<String, Object>>) ((Map<String, Object>) response.get("data")).get("allIceds");
+    }
+
+    public List<Map<String, Object>> getAllHotCoffees(Map<String, Object> response) {
+        return (List<Map<String, Object>>) ((Map<String, Object>) response.get("data")).get("allHots");
+    }
+}

--- a/src/main/resources/graphql/query.graphql
+++ b/src/main/resources/graphql/query.graphql
@@ -1,0 +1,14 @@
+{
+    allIceds {
+        id
+        ingredients
+        image
+        title
+    },
+    allHots {
+        id
+        ingredients
+        image
+        title
+    }
+}

--- a/src/test/java/net/ironoc/portfolio/controller/CoffeeControllerIntegrationTest.java
+++ b/src/test/java/net/ironoc/portfolio/controller/CoffeeControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package net.ironoc.portfolio.controller;
 
 import net.ironoc.portfolio.domain.CoffeeDomain;
+import net.ironoc.portfolio.service.GraphQLClientService;
 import net.ironoc.portfolio.service.CoffeesCache;
 import net.ironoc.portfolio.service.CoffeesService;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,9 @@ public class CoffeeControllerIntegrationTest extends ControllerIntegrationTest {
 
     @MockitoBean
     private CoffeesCache coffeesCacheMock;
+
+    @MockitoBean
+    private GraphQLClientService graphQLClientServiceMock;
 
     private MockMvc mockMvc;
 

--- a/src/test/java/net/ironoc/portfolio/controller/GitProjectsControllerIntegrationTest.java
+++ b/src/test/java/net/ironoc/portfolio/controller/GitProjectsControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package net.ironoc.portfolio.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.ironoc.portfolio.dto.RepositoryDetailDto;
 import net.ironoc.portfolio.dto.RepositoryIssueDto;
+import net.ironoc.portfolio.service.GraphQLClientService;
 import net.ironoc.portfolio.service.GitDetailsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,9 @@ public class GitProjectsControllerIntegrationTest extends ControllerIntegrationT
 
     @MockitoBean
     private GitDetailsService gitDetailsServiceMock;
+
+    @MockitoBean
+    private GraphQLClientService graphQLClientServiceMock;
 
     @InjectMocks
     private GitProjectsController gitProjectsController;// controller under test


### PR DESCRIPTION
- [ ] #244 

Coffee API changed ingredients format for REST API calls so migrating to graphQL query instead.
This release needs major follow up changes, refactoring, & tests, see #243 