### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ironoc/security/code-scanning/9](https://github.com/conorheffron/ironoc/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require any write permissions, we can set the permissions to `contents: read`. This limits the `GITHUB_TOKEN` to read-only access to the repository contents, which is sufficient for the current workflow tasks. The `permissions` block should be added at the root level of the workflow file to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
