### PR TITLE
#363 Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ironoc/security/code-scanning/10](https://github.com/conorheffron/ironoc/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `build` job, explicitly setting it to `contents: read`. This ensures the job has only the permissions necessary to read repository contents, which is sufficient for its operations (e.g., running tests). No write permissions are required for this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
