### PR TITLE
#363 Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ironoc/security/code-scanning/11](https://github.com/conorheffron/ironoc/security/code-scanning/11)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses the `anishathalye/proof-html` action, which likely only requires read access to the repository contents, we can set `contents: read` as the minimal permission. This change will ensure that the workflow adheres to the principle of least privilege while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
