### PR TITLE
Release Patch v7.4.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.4.5",
+  "version": "7.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorheffron/ironoc-frontend",
-      "version": "7.4.5",
+      "version": "7.4.6",
       "dependencies": {
         "@apollo/client": "^3.13.8",
         "@fontsource/montserrat": "^5.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.4.5",
+  "version": "7.4.6",
   "private": false,
   "dependencies": {
     "@apollo/client": "^3.13.8",

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>conorheffron</groupId>
 	<artifactId>ironoc</artifactId>
-	<version>7.4.5</version>
+	<version>7.4.6</version>
 	<packaging>war</packaging>
 
 	<distributionManagement>

--- a/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
+++ b/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
@@ -41,7 +41,7 @@ public class RemoteBrowserBasedIntTest extends BaseControllerIntegrationTest {
     @Autowired
     private WebDriver webDriver;
 
-//    @Test
+    @Test
     public void test_quick_tour() {
         try {
             Dimension dimension = new Dimension(878, 963);// mimic small device size


### PR DESCRIPTION
Re-enable remote integration test after unexpected downtime introduced by runtime crash due to missing GraphQL mapping configuration for new mutation.