### PR TITLE
Release v7.6.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@conorheffron/ironoc-frontend",
-      "version": "7.6.2",
+      "version": "7.6.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@apollo/client": "^3.13.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@conorheffron/ironoc-frontend",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "private": false,
   "license": "GPL-3.0-or-later",
   "dependencies": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>conorheffron</groupId>
 	<artifactId>ironoc</artifactId>
-	<version>7.6.2</version>
+	<version>7.6.3</version>
 	<packaging>war</packaging>
 
 	<distributionManagement>

--- a/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
+++ b/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
@@ -41,7 +41,7 @@ public class RemoteBrowserBasedIntTest extends BaseControllerIntegrationTest {
     @Autowired
     private WebDriver webDriver;
 
-    @Test
+    // @Test
     public void test_quick_tour() {
         try {
             Dimension dimension = new Dimension(878, 963);// mimic small device size

--- a/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
+++ b/src/test/java/net/ironoc/portfolio/RemoteBrowserBasedIntTest.java
@@ -41,7 +41,7 @@ public class RemoteBrowserBasedIntTest extends BaseControllerIntegrationTest {
     @Autowired
     private WebDriver webDriver;
 
-    // @Test
+    @Test
     public void test_quick_tour() {
         try {
             Dimension dimension = new Dimension(878, 963);// mimic small device size


### PR DESCRIPTION
 - [x] #431
 - [x] #432 
 - [x] #433 
 - [x] #434 
 - [x] #435 
 - [x] #441
 - [x] https://github.com/conorheffron/ironoc/security/dependabot/27
 - [x] https://github.com/conorheffron/ironoc/security/dependabot/28
 - [x] https://github.com/conorheffron/ironoc/security/dependabot/29
 - [x] Note: Temp disable of Selenium 'quick tour' as it passes locally but not on GithHub CI build.
 